### PR TITLE
Configure GitHub Pages deployment with WASM build

### DIFF
--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -26,12 +26,9 @@ jobs:
         run: cargo test --workspace
         working-directory: ./rs-code
 
-  build-and-deploy:
+  build-wasm:
     runs-on: ubuntu-latest
     needs: test
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -58,13 +55,33 @@ jobs:
         run: cp page.html dist/index.html
         working-directory: ./rs-code/loxwasm
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-dist
+          path: './rs-code/loxwasm/dist'
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-wasm
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-dist
+          path: './dist'
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './rs-code/loxwasm/dist'
+          path: './dist'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -29,6 +29,9 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     needs: test
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -2,7 +2,9 @@ name: Build and Deploy to GitHub Pages
 
 on:
   push:
-    branches: ["**"]  # Trigger on all branches
+    branches: ["main"]  # Trigger on all branches
+  pull_request:
+    branches: ["main"]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -1,36 +1,68 @@
-# This is a basic workflow to help you get started with Actions
+name: Build and Deploy to GitHub Pages
 
-name: CI
-
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: [ "main" ]
-
-  # Allows you to run this workflow manually from the Actions tab
+    branches: ["**"]  # Trigger on all branches
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
-jobs:
-  # This workflow contains a single job called "build"
-  test:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test --workspace
+      - name: Run tests
+        run: cargo test --workspace
         working-directory: ./rs-code
-        name: Test
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo "Hello, world!" > index.html
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
 
-      # - name: Deploy to GitHub Pages
-      #   id: deployment
-      #   uses: actions/deploy-pages@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli
+
+      - name: Build WASM
+        run: cargo build --release --target wasm32-unknown-unknown
+        working-directory: ./rs-code/loxwasm
+
+      - name: Generate JS bindings
+        run: |
+          wasm-bindgen ../target/wasm32-unknown-unknown/release/loxwasm.wasm \
+            --out-dir ./dist \
+            --target web \
+            --no-typescript
+        working-directory: ./rs-code/loxwasm
+
+      - name: Copy HTML to dist
+        run: cp page.html dist/index.html
+        working-directory: ./rs-code/loxwasm
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './rs-code/loxwasm/dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Add WASM build step using cargo and wasm-bindgen
- Set up proper GitHub Pages permissions and deployment
- Trigger workflow on all branches for testing
- Run tests before building and deploying
- Generate JS bindings and deploy to GitHub Pages