### PR TITLE
Add structured enum result type with span info to WASM functions

### DIFF
--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: wasm-bindgen
+          tool: wasm-bindgen,wasm-pack
 
       - name: Build WASM
         run: cargo build --release --target wasm32-unknown-unknown
@@ -48,9 +48,9 @@ jobs:
 
       - name: Generate JS bindings
         run: |
-          wasm-bindgen ../rs-code/target/wasm32-unknown-unknown/release/loxwasm.wasm \
-            --out-dir ./dist \
-            --target web
+          wasm-pack ../rs-code/loxwasm \
+            --out-dir ./loxwasm-pkg \
+            --target bundler
         working-directory: ./playground
 
       - name: Setup Node.js

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Generate JS bindings
         run: |
-          wasm-pack ../rs-code/loxwasm \
+          wasm-pack build ../rs-code/loxwasm \
             --out-dir ./loxwasm-pkg \
             --target bundler
         working-directory: ./playground

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -48,10 +48,9 @@ jobs:
 
       - name: Generate JS bindings
         run: |
-          wasm-pack build ../rs-code/loxwasm \
-            --out-dir ./loxwasm-pkg \
+          wasm-pack build $GITHUB_WORKSPACE/rs-code/loxwasm \
+            --out-dir $GITHUB_WORKSPACE/playground/loxwasm-pkg \
             --target bundler
-        working-directory: ./playground
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Rust build artifacts
+rs-code/target/

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ build-wasm:
 	cd rs-code/loxwasm && cargo build --release --target wasm32-unknown-unknown
 	@echo "Generating JavaScript bindings..."
 	wasm-bindgen $(CARGO_TARGET_DIR)/wasm32-unknown-unknown/release/loxwasm.wasm \
-		--out-dir playground/dist \
-		--target web
+		--out-dir playground/loxwasm-pkg \
+		--target bundler
 	@echo "WASM build complete!"
 
 # Run TypeScript tests

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -19,6 +19,7 @@
         "happy-dom": "^12.10.3",
         "typescript": "^5.3.3",
         "vite": "^5.0.11",
+        "vite-plugin-wasm": "^3.5.0",
         "vitest": "^1.2.0"
       }
     },
@@ -2114,6 +2115,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2189,6 +2191,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-wasm": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.5.0.tgz",
+      "integrity": "sha512-X5VWgCnqiQEGb+omhlBVsvTfxikKtoOgAzQ95+BZ8gQ+VfMHIjSHr0wyvXFQCa0eKQ0fKyaL0kWcEnYqBac4lQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7"
       }
     },
     "node_modules/vitest": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -10,11 +10,12 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@vitest/ui": "^1.2.0",
+    "happy-dom": "^12.10.3",
     "typescript": "^5.3.3",
     "vite": "^5.0.11",
-    "vitest": "^1.2.0",
-    "@vitest/ui": "^1.2.0",
-    "happy-dom": "^12.10.3"
+    "vite-plugin-wasm": "^3.5.0",
+    "vitest": "^1.2.0"
   },
   "dependencies": {
     "@codemirror/commands": "^6.3.3",

--- a/playground/src/wasm.test.ts
+++ b/playground/src/wasm.test.ts
@@ -6,8 +6,7 @@ describe('WASM Module Integration', () => {
     beforeAll(async () => {
         try {
             // Dynamically import the WASM module
-            const { default: init, eval_expr, run_program } = await import('../dist/loxwasm.js');
-            await init();
+            const { eval_expr, run_program } = await import('../loxwasm-pkg/loxwasm');
             wasmModule = { eval_expr, run_program };
         } catch (error) {
             console.warn('WASM module not available, skipping integration tests:', error);

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vite';
+import wasm from 'vite-plugin-wasm';
 
 export default defineConfig({
   base: './',
+  plugins: [wasm()],
   build: {
     target: 'es2022', // Support top-level await
     outDir: 'dist',

--- a/rs-code/Cargo.lock
+++ b/rs-code/Cargo.lock
@@ -172,6 +172,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "gloo-utils"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +201,22 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -225,7 +254,10 @@ version = "0.1.0"
 dependencies = [
  "loxlang",
  "miette",
+ "serde",
+ "serde-wasm-bindgen",
  "thiserror",
+ "tsify",
  "wasm-bindgen",
 ]
 
@@ -361,6 +393,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.148"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +536,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tsify"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b26cf145f2f3b9ff84e182c448eaf05468e247f148cf3d2a7d67d78ff023a0"
+dependencies = [
+ "gloo-utils",
+ "serde",
+ "serde_json",
+ "tsify-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-macros"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a94b0f0954b3e59bfc2c246b4c8574390d94a4ad4ad246aaf2fb07d7dfd3b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +633,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -601,3 +733,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "zmij"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d6085d62852e35540689d1f97ad663e3971fc19cf5eceab364d62c646ea167"

--- a/rs-code/loxwasm/Cargo.toml
+++ b/rs-code/loxwasm/Cargo.toml
@@ -8,6 +8,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
+serde = { version = "1.0", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+tsify = "0.4"
 loxlang = { path = "../loxlang"}
 thiserror.workspace = true
 miette = { version = "7", features = [] }

--- a/rs-code/loxwasm/src/lib.rs
+++ b/rs-code/loxwasm/src/lib.rs
@@ -6,8 +6,41 @@ use loxlang::resolution::resolve;
 use loxlang::resolution::resolve_expr_no_var;
 use miette::Diagnostic;
 use miette::NarratableReportHandler;
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
+
+/// Span information indicating where an error occurred in the source code
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct ErrorSpan {
+    /// The byte offset where the error starts
+    pub start: usize,
+    /// The byte offset where the error ends
+    pub end: usize,
+}
+
+/// Structured error information with location details
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct ErrorInfo {
+    /// The error message
+    pub message: String,
+    /// The span in the source code where the error occurred
+    pub span: ErrorSpan,
+    /// The type of error (e.g., "lexical", "resolution", "runtime")
+    pub error_type: String,
+}
+
+/// Result type for Lox operations
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(tag = "type", content = "value")]
+pub enum LoxResult<T> {
+    Success(T),
+    Error(ErrorInfo),
+}
 
 #[derive(Debug)]
 pub struct LoxError(String);
@@ -28,41 +61,105 @@ impl<T: Diagnostic> From<T> for LoxError {
     }
 }
 
-#[wasm_bindgen]
-pub fn eval_expr(src: String) -> Result<f64, LoxError> {
-    let tokens = parse::scanner::parse_tokens(&src)?;
-    let mut p = parse::Parser::new(&src, &tokens);
-    let e = p.parse_expr()?;
-    let e = resolve_expr_no_var(e, &src)?;
-    if !p.done() {
-        return Err(LoxError("Unparsed tokens remaining".to_string()));
-    }
-    let deps = TestDeps {
-        printed: Vec::new(),
+/// Helper function to convert a Diagnostic error into ErrorInfo
+fn diagnostic_to_error_info<T: Diagnostic>(error: T, error_type: &str) -> ErrorInfo {
+    let mut output = String::new();
+    NarratableReportHandler::new()
+        .render_report(&mut output, &error)
+        .unwrap();
+
+    // Extract span information from the error's labels
+    let span = if let Some(labels) = error.labels() {
+        if let Some(label) = labels.into_iter().next() {
+            let span = label.inner();
+            ErrorSpan {
+                start: span.offset(),
+                end: span.offset() + span.len(),
+            }
+        } else {
+            ErrorSpan { start: 0, end: 0 }
+        }
+    } else {
+        ErrorSpan { start: 0, end: 0 }
     };
-    let env = loxlang::execution_env::ExecEnv::new(deps);
-    let mut runtime = loxlang::runtime::Runtime::new(env);
-    match runtime.eval(&e) {
-        Ok(Value::Atomic(AtomicValue::Number(x))) => Ok(x),
-        Err(e) => Err(LoxError(format!("Evaluation error: {:?}", e))),
-        _ => Err(LoxError(
-            "Expected number, got non-number value".to_string(),
-        )),
+
+    ErrorInfo {
+        message: output,
+        span,
+        error_type: error_type.to_string(),
     }
 }
 
 #[wasm_bindgen]
-pub fn run_program(src: String) -> Result<Vec<String>, LoxError> {
-    let tokens = parse::scanner::parse_tokens(&src)?;
-    let program = parse::Parser::new(&src, &tokens).parse_program()?;
-    let program = resolve(program, &src)?;
+pub fn eval_expr(src: String) -> LoxResult<f64> {
+    let tokens = match parse::scanner::parse_tokens(&src) {
+        Ok(tokens) => tokens,
+        Err(e) => return LoxResult::Error(diagnostic_to_error_info(e, "lexical")),
+    };
+
+    let mut p = parse::Parser::new(&src, &tokens);
+    let e = match p.parse_expr() {
+        Ok(e) => e,
+        Err(e) => return LoxResult::Error(diagnostic_to_error_info(e, "parse")),
+    };
+
+    let e = match resolve_expr_no_var(e, &src) {
+        Ok(e) => e,
+        Err(e) => return LoxResult::Error(diagnostic_to_error_info(e, "resolution")),
+    };
+
+    if !p.done() {
+        return LoxResult::Error(ErrorInfo {
+            message: "Unparsed tokens remaining".to_string(),
+            span: ErrorSpan { start: 0, end: 0 },
+            error_type: "parse".to_string(),
+        });
+    }
+
     let deps = TestDeps {
         printed: Vec::new(),
     };
     let env = loxlang::execution_env::ExecEnv::new(deps);
     let mut runtime = loxlang::runtime::Runtime::new(env);
-    runtime.run_program(&program)?;
-    Ok(runtime.into_deps().printed)
+
+    match runtime.eval(&e) {
+        Ok(Value::Atomic(AtomicValue::Number(x))) => LoxResult::Success(x),
+        Err(e) => LoxResult::Error(diagnostic_to_error_info(e, "runtime")),
+        _ => LoxResult::Error(ErrorInfo {
+            message: "Expected number, got non-number value".to_string(),
+            span: ErrorSpan { start: 0, end: 0 },
+            error_type: "type".to_string(),
+        }),
+    }
+}
+
+#[wasm_bindgen]
+pub fn run_program(src: String) -> LoxResult<Vec<String>> {
+    let tokens = match parse::scanner::parse_tokens(&src) {
+        Ok(tokens) => tokens,
+        Err(e) => return LoxResult::Error(diagnostic_to_error_info(e, "lexical")),
+    };
+
+    let program = match parse::Parser::new(&src, &tokens).parse_program() {
+        Ok(program) => program,
+        Err(e) => return LoxResult::Error(diagnostic_to_error_info(e, "parse")),
+    };
+
+    let program = match resolve(program, &src) {
+        Ok(program) => program,
+        Err(e) => return LoxResult::Error(diagnostic_to_error_info(e, "resolution")),
+    };
+
+    let deps = TestDeps {
+        printed: Vec::new(),
+    };
+    let env = loxlang::execution_env::ExecEnv::new(deps);
+    let mut runtime = loxlang::runtime::Runtime::new(env);
+
+    match runtime.run_program(&program) {
+        Ok(_) => LoxResult::Success(runtime.into_deps().printed),
+        Err(e) => LoxResult::Error(diagnostic_to_error_info(e, "runtime")),
+    }
 }
 
 struct TestDeps {


### PR DESCRIPTION
- Added serde, serde-wasm-bindgen, and tsify dependencies
- Created LoxResult enum with Success and Error variants
- Created ErrorInfo struct with message, span, and error_type fields
- Created ErrorSpan struct to track byte offsets in source code
- Updated eval_expr and run_program to return LoxResult instead of Result
- Implemented diagnostic_to_error_info to extract span info from miette errors
- All TypeScript types are automatically generated via tsify