### PR TITLE
Update test runner to use chumsky parser

### DIFF
--- a/rs-code/loxlang/src/parse/mod.rs
+++ b/rs-code/loxlang/src/parse/mod.rs
@@ -565,13 +565,13 @@ where
 /// 3. var_name is None and start is Some: this is `x = 0;` case where an existing variable is used, and the expression is typically an assignment
 /// 4. Both are none: here the first part is empty `for(;...)`, initialization is done outside the loop
 #[derive(Debug, Clone)]
-struct ForLoopDef<'a, VR, VD, Ann> {
-    var_name: Option<VariableDecl<VD>>,
-    start: Option<AnnotatedExpression<'a, VR, Ann>>,
-    cond: Option<AnnotatedExpression<'a, VR, Ann>>,
-    increment: Option<AnnotatedExpression<'a, VR, Ann>>,
+pub struct ForLoopDef<'a, VR, VD, Ann> {
+    pub var_name: Option<VariableDecl<VD>>,
+    pub start: Option<AnnotatedExpression<'a, VR, Ann>>,
+    pub cond: Option<AnnotatedExpression<'a, VR, Ann>>,
+    pub increment: Option<AnnotatedExpression<'a, VR, Ann>>,
 }
-fn for_loop_into_while_loop<'src>(
+pub fn for_loop_into_while_loop<'src>(
     loopdef: ForLoopDef<'src, &'src str, &'src str, ByteSpan>,
     body: ParsedStatement<'src>,
 ) -> ParsedStatement<'src> {

--- a/rs-code/loxlang/src/test_runner.rs
+++ b/rs-code/loxlang/src/test_runner.rs
@@ -1,7 +1,7 @@
 use crate::execution_env::{Deps, ExecEnv, Value};
-use crate::parse;
-use crate::parse::scanner::parse_tokens;
+use crate::parse::chumsky_parser::{lexer, program_parser};
 use crate::runtime::Runtime;
+use chumsky::Parser;
 use regex::Regex;
 use std::fs;
 use std::path::Path;
@@ -119,12 +119,14 @@ impl TestCase {
         // Strip comments from source before parsing
         let source_without_comments = Self::strip_comments(&self.source);
 
-        let tokens =
-            parse_tokens(&source_without_comments).map_err(|e| format!("Lexical error: {}", e))?;
-        let parser = parse::Parser::new(&source_without_comments, &tokens);
-        let program = parser
-            .parse_program()
-            .map_err(|e| format!("Parse error: {}", e))?;
+        let tokens = lexer()
+            .parse(&source_without_comments)
+            .into_result()
+            .map_err(|e| format!("Lexical error: {:?}", e))?;
+        let program = program_parser()
+            .parse(&tokens)
+            .into_result()
+            .map_err(|e| format!("Parse error: {:?}", e))?;
         let program = crate::resolution::resolve(program, &source_without_comments)
             .map_err(|e| format!("Resolution error: {}", e))?;
 


### PR DESCRIPTION
- Replace scanner/parse::Parser with chumsky lexer and program_parser
- Use lexer().parse() for tokenization
- Use program_parser().parse() for parsing
