### PR TITLE
Refactor lexer and parser into single combined parser

### DIFF
--- a/rs-code/loxlang/src/lib.rs
+++ b/rs-code/loxlang/src/lib.rs
@@ -51,42 +51,17 @@ impl LoxError {
 pub fn parse_program(source: &str) -> Result<RunnableProgram<'_>, LoxError> {
     use chumsky::Parser;
 
-    let tokens = parse::chumsky_parser::lexer()
+    let program = parse::chumsky_parser::program_parser()
         .parse(source)
         .into_result()
         .map_err(|errors| {
             let err = errors.into_iter().next().unwrap();
             let span = err.span();
-            parse::LexicalError {
-                src: source.to_string(),
-                source_offset: span.start.into(),
-            }
-        })?;
-
-    let program = parse::chumsky_parser::program_parser()
-        .parse(&tokens)
-        .into_result()
-        .map_err(|errors| {
-            let err = errors.into_iter().next().unwrap();
-            let token_span = err.span();
-
-            // Map token indices to character positions
-            let char_span = if token_span.start < tokens.len() {
-                let start_char = tokens[token_span.start].1.start;
-                let end_char = if token_span.end <= tokens.len() && token_span.end > 0 {
-                    tokens[token_span.end - 1].1.end
-                } else {
-                    tokens[token_span.start].1.end
-                };
-                miette::SourceSpan::new(start_char.into(), end_char - start_char)
-            } else {
-                miette::SourceSpan::new(source.len().into(), 0)
-            };
 
             parse::ParseError::UnexpectedToken {
                 src: source.to_string(),
-                span: char_span,
-                help: format!("Unexpected token while parsing program"),
+                span: miette::SourceSpan::new(span.start.into(), span.end - span.start),
+                help: format!("Unexpected input while parsing program"),
             }
         })?;
 

--- a/rs-code/loxlang/src/parse/chumsky_parser.rs
+++ b/rs-code/loxlang/src/parse/chumsky_parser.rs
@@ -3,9 +3,6 @@ use crate::syntax::*;
 use chumsky::pratt::{infix, left, postfix, prefix, right};
 use chumsky::prelude::*;
 
-/// Simple example parser using chumsky
-/// This parser works directly on source strings without a separate lexer phase
-
 type ParsedExpression<'src> = AnnotatedExpression<'src, &'src str, ByteSpan>;
 
 /// Helper to convert SimpleSpan to ByteSpan
@@ -16,7 +13,7 @@ fn to_byte_span(span: SimpleSpan) -> ByteSpan {
     }
 }
 
-/// Parser for expressions working directly on source strings
+/// Parser for expressions
 pub fn expr_parser<'src>() -> impl Parser<
     'src,
     &'src str,

--- a/rs-code/loxlang/src/parse/chumsky_parser.rs
+++ b/rs-code/loxlang/src/parse/chumsky_parser.rs
@@ -1,125 +1,12 @@
 use crate::parse::{for_loop_into_while_loop, ByteSpan, ForLoopDef};
 use crate::syntax::*;
-use chumsky::input::MapExtra;
 use chumsky::pratt::{infix, left, postfix, prefix, right};
 use chumsky::prelude::*;
 
 /// Simple example parser using chumsky
-/// This starts with basic expressions: literals, binary operations, and parentheses
+/// This parser works directly on source strings without a separate lexer phase
 
 type ParsedExpression<'src> = AnnotatedExpression<'src, &'src str, ByteSpan>;
-
-/// Token type for our lexer
-#[derive(Clone, Debug, PartialEq)]
-pub enum Token<'a> {
-    Number(f64),
-    String(&'a str),
-    True,
-    False,
-    Nil,
-    Ident(&'a str),
-
-    // Keywords
-    Print,
-    Var,
-    If,
-    Else,
-    While,
-    For,
-    Fun,
-    Return,
-    And,
-    Or,
-
-    // Operators
-    Plus,
-    Minus,
-    Star,
-    Slash,
-
-    // Delimiters
-    LParen,
-    RParen,
-    LBrace,
-    RBrace,
-    Semicolon,
-    Comma,
-
-    // Comparison
-    Equal,
-    EqualEqual,
-    Bang,
-    BangEqual,
-    Less,
-    Greater,
-    LessEqual,
-    GreaterEqual,
-}
-
-/// Lexer that converts source code into tokens
-pub fn lexer<'a>(
-) -> impl Parser<'a, &'a str, Vec<(Token<'a>, SimpleSpan)>, extra::Err<Simple<'a, char>>> {
-    let number = text::int(10)
-        .then(just('.').then(text::digits(10)).or_not())
-        .to_slice()
-        .from_str::<f64>()
-        .unwrapped()
-        .map(Token::Number)
-        .labelled("number");
-
-    let string = just('"')
-        .ignore_then(none_of('"').repeated().to_slice())
-        .then_ignore(just('"'))
-        .map(Token::String)
-        .labelled("string");
-
-    let operator = choice((
-        just("==").to(Token::EqualEqual),
-        just("!=").to(Token::BangEqual),
-        just("<=").to(Token::LessEqual),
-        just(">=").to(Token::GreaterEqual),
-        just('=').to(Token::Equal),
-        just('!').to(Token::Bang),
-        just('<').to(Token::Less),
-        just('>').to(Token::Greater),
-        just('+').to(Token::Plus),
-        just('-').to(Token::Minus),
-        just('*').to(Token::Star),
-        just('/').to(Token::Slash),
-    ));
-
-    let delimiter = choice((
-        just('(').to(Token::LParen),
-        just(')').to(Token::RParen),
-        just('{').to(Token::LBrace),
-        just('}').to(Token::RBrace),
-        just(';').to(Token::Semicolon),
-        just(',').to(Token::Comma),
-    ));
-
-    let keyword = text::ascii::ident().map(|s: &str| match s {
-        "true" => Token::True,
-        "false" => Token::False,
-        "nil" => Token::Nil,
-        "print" => Token::Print,
-        "var" => Token::Var,
-        "if" => Token::If,
-        "else" => Token::Else,
-        "while" => Token::While,
-        "for" => Token::For,
-        "fun" => Token::Fun,
-        "return" => Token::Return,
-        "and" => Token::And,
-        "or" => Token::Or,
-        _ => Token::Ident(s),
-    });
-
-    let token = choice((number, string, operator, delimiter, keyword))
-        .padded_by(text::whitespace())
-        .map_with(|tok, e| (tok, e.span()));
-
-    token.repeated().collect().then_ignore(end())
-}
 
 /// Helper to convert SimpleSpan to ByteSpan
 fn to_byte_span(span: SimpleSpan) -> ByteSpan {
@@ -129,79 +16,98 @@ fn to_byte_span(span: SimpleSpan) -> ByteSpan {
     }
 }
 
-/// Parser that converts tokens into AST expressions
-pub fn expr_parser<'a, 'src: 'a>() -> impl Parser<
-    'a,
-    &'a [(Token<'src>, SimpleSpan)],
+/// Parser for expressions working directly on source strings
+pub fn expr_parser<'src>() -> impl Parser<
+    'src,
+    &'src str,
     ParsedExpression<'src>,
-    extra::Err<Simple<'a, (Token<'src>, SimpleSpan)>>,
+    extra::Err<Simple<'src, char>>,
 > + Clone {
     recursive(|expr| {
-        // Primary expressions: literals and parenthesized expressions
-        let literal = select! {
-            (Token::Number(n), span) => Expression::NumberLiteral(n).annotate(to_byte_span(span)),
-            (Token::String(s), span) => Expression::StringLiteral(s).annotate(to_byte_span(span)),
-            (Token::True, span) => Expression::BooleanLiteral(true).annotate(to_byte_span(span)),
-            (Token::False, span) => Expression::BooleanLiteral(false).annotate(to_byte_span(span)),
-            (Token::Nil, span) => Expression::Nil.annotate(to_byte_span(span)),
-        }
-        .labelled("literal");
+        // Parse numbers
+        let number = text::int(10)
+            .then(just('.').then(text::digits(10)).or_not())
+            .to_slice()
+            .from_str::<f64>()
+            .unwrapped()
+            .map_with(|n, e| Expression::NumberLiteral(n).annotate(to_byte_span(e.span())))
+            .labelled("number");
 
-        let ident = select! {
-            (Token::Ident(s), span) => (s, span),
-        }
-        .map(|(name, span)| Expression::Identifier(Variable(name)).annotate(to_byte_span(span)))
+        // Parse strings
+        let string = just('"')
+            .ignore_then(none_of('"').repeated().to_slice())
+            .then_ignore(just('"'))
+            .map_with(|s: &'src str, e| {
+                Expression::StringLiteral(s).annotate(to_byte_span(e.span()))
+            })
+            .labelled("string");
+
+        // Parse identifiers and keywords
+        let ident = text::ascii::ident().map_with(|s: &'src str, e| match s {
+            "true" => Expression::BooleanLiteral(true).annotate(to_byte_span(e.span())),
+            "false" => Expression::BooleanLiteral(false).annotate(to_byte_span(e.span())),
+            "nil" => Expression::Nil.annotate(to_byte_span(e.span())),
+            _ => Expression::Identifier(Variable(s)).annotate(to_byte_span(e.span())),
+        })
         .labelled("identifier");
 
-        let lparen = select! { (Token::LParen, _) => () };
-        let rparen = select! { (Token::RParen, _) => () };
-        let comma = select! { (Token::Comma, _) => () };
+        // Delimiters
+        let lparen = just('(').padded();
+        let rparen = just(')').padded();
+        let comma = just(',').padded();
+
+        // Primary expressions (atoms)
+        let literal = choice((number, string));
 
         let atom = choice((
             literal,
             ident,
             expr.clone()
+                .padded()
                 .delimited_by(lparen.clone(), rparen.clone())
                 .labelled("parenthesized expression"),
-        ));
+        ))
+        .padded();
 
         // Define operator parsers for each precedence level
-        let equal = select! { (Token::Equal, _) => () };
+        let equal = just('=').padded();
 
-        let or_op = select! { (Token::Or, _) => BOperator::OR };
-        let and_op = select! { (Token::And, _) => BOperator::AND };
+        let or_op = text::keyword("or").padded().to(BOperator::OR);
+        let and_op = text::keyword("and").padded().to(BOperator::AND);
 
         let equality_op = choice((
-            select! { (Token::EqualEqual, _) => BOperator::EqualEqual },
-            select! { (Token::BangEqual, _) => BOperator::BangEqual },
+            just("==").padded().to(BOperator::EqualEqual),
+            just("!=").padded().to(BOperator::BangEqual),
         ));
 
         let comparison_op = choice((
-            select! { (Token::Less, _) => BOperator::LESS },
-            select! { (Token::Greater, _) => BOperator::GREATER },
-            select! { (Token::LessEqual, _) => BOperator::LessEqual },
-            select! { (Token::GreaterEqual, _) => BOperator::GreaterEqual },
+            just("<=").padded().to(BOperator::LessEqual),
+            just(">=").padded().to(BOperator::GreaterEqual),
+            just('<').padded().to(BOperator::LESS),
+            just('>').padded().to(BOperator::GREATER),
         ));
 
         let term_op = choice((
-            select! { (Token::Plus, _) => BOperator::PLUS },
-            select! { (Token::Minus, _) => BOperator::MINUS },
+            just('+').padded().to(BOperator::PLUS),
+            just('-').padded().to(BOperator::MINUS),
         ));
 
         let factor_op = choice((
-            select! { (Token::Star, _) => BOperator::STAR },
-            select! { (Token::Slash, _) => BOperator::SLASH },
+            just('*').padded().to(BOperator::STAR),
+            just('/').padded().to(BOperator::SLASH),
         ));
 
         let unary_op = choice((
-            select! { (Token::Minus, _) => UOperator::MINUS },
-            select! { (Token::Bang, _) => UOperator::BANG },
+            just('-').padded().to(UOperator::MINUS),
+            just('!').padded().to(UOperator::BANG),
         ));
 
         // Function calls: foo(arg1, arg2, ...)
         let arg_list = expr
             .clone()
+            .padded()
             .separated_by(comma)
+            .allow_trailing()
             .collect::<Vec<_>>()
             .delimited_by(lparen, rparen);
 
@@ -209,7 +115,6 @@ pub fn expr_parser<'a, 'src: 'a>() -> impl Parser<
             left: ParsedExpression<'a>,
             op: BOperator,
             right: ParsedExpression<'a>,
-            // e: &mut MapExtra<'src, 'a, (Token<'src>, SimpleSpan), extra::Err<Simple<'a, (Token<'src>, SimpleSpan)>>>,
         ) -> ParsedExpression<'a> {
             let l_ann = left.annotation;
             let r_ann = right.annotation;
@@ -283,36 +188,36 @@ pub fn expr_parser<'a, 'src: 'a>() -> impl Parser<
 type ParsedDeclaration<'src> = Declaration<'src, &'src str, &'src str, ByteSpan>;
 
 /// Parser for statements and declarations (combined to avoid mutual recursion issues)
-pub fn decl_parser<'a, 'src: 'a>() -> impl Parser<
-    'a,
-    &'a [(Token<'src>, SimpleSpan)],
+pub fn decl_parser<'src>() -> impl Parser<
+    'src,
+    &'src str,
     ParsedDeclaration<'src>,
-    extra::Err<Simple<'a, (Token<'src>, SimpleSpan)>>,
+    extra::Err<Simple<'src, char>>,
 > + Clone {
     recursive(|decl| {
         let expr = expr_parser();
-        let semicolon = select! { (Token::Semicolon, _) => () };
-        let equal = select! { (Token::Equal, _) => () };
-        let comma = select! { (Token::Comma, _) => () };
-        let lparen = select! { (Token::LParen, _) => () };
-        let rparen = select! { (Token::RParen, _) => () };
-        let lbrace = select! { (Token::LBrace, _) => () };
-        let rbrace = select! { (Token::RBrace, _) => () };
+        let semicolon = just(';').padded();
+        let equal = just('=').padded();
+        let comma = just(',').padded();
+        let lparen = just('(').padded();
+        let rparen = just(')').padded();
+        let lbrace = just('{').padded();
+        let rbrace = just('}').padded();
 
-        let ident = select! {
-            (Token::Ident(s), _) => s,
-        };
+        let ident = text::ascii::ident().padded();
 
         // Statements (defined inline to avoid mutual recursion)
         let stmt = recursive(|stmt| {
             // Print statement
-            let print_stmt = select! { (Token::Print, _) => () }
+            let print_stmt = text::keyword("print")
+                .padded()
                 .ignore_then(expr.clone())
                 .then_ignore(semicolon.clone())
                 .map_with(|e, ann| Statement::Print(e).annotate(to_byte_span(ann.span())));
 
             // Return statement
-            let return_stmt = select! { (Token::Return, _) => () }
+            let return_stmt = text::keyword("return")
+                .padded()
                 .ignore_then(expr.clone().or_not())
                 .then_ignore(semicolon.clone())
                 .map_with(|e, ann| {
@@ -331,17 +236,20 @@ pub fn decl_parser<'a, 'src: 'a>() -> impl Parser<
             // Block statement
             let block = decl
                 .clone()
+                .padded()
                 .repeated()
                 .collect()
                 .delimited_by(lbrace.clone(), rbrace.clone())
                 .map_with(|decls, ann| Statement::Block(decls).annotate(to_byte_span(ann.span())));
 
             // If statement
-            let if_stmt = select! { (Token::If, _) => () }
+            let if_stmt = text::keyword("if")
+                .padded()
                 .ignore_then(expr.clone().delimited_by(lparen.clone(), rparen.clone()))
                 .then(stmt.clone())
                 .then(
-                    select! { (Token::Else, _) => () }
+                    text::keyword("else")
+                        .padded()
                         .ignore_then(stmt.clone())
                         .or_not(),
                 )
@@ -351,7 +259,8 @@ pub fn decl_parser<'a, 'src: 'a>() -> impl Parser<
                 });
 
             // While statement
-            let while_stmt = select! { (Token::While, _) => () }
+            let while_stmt = text::keyword("while")
+                .padded()
                 .ignore_then(expr.clone().delimited_by(lparen.clone(), rparen.clone()))
                 .then(stmt.clone())
                 .map_with(|(cond, body), ann| {
@@ -368,13 +277,15 @@ pub fn decl_parser<'a, 'src: 'a>() -> impl Parser<
             //     incr;
             //   }
             // }
-            let for_stmt = select! { (Token::For, _) => () }
+            let for_stmt = text::keyword("for")
+                .padded()
                 .ignore_then(lparen.clone())
                 .ignore_then(
                     // Parse initializer - can be var declaration, expression, or empty
                     choice((
                         // var x = expr;
-                        select! { (Token::Var, _) => () }
+                        text::keyword("var")
+                            .padded()
                             .ignore_then(ident.clone())
                             .then(equal.clone().ignore_then(expr.clone()).or_not())
                             .then_ignore(semicolon.clone())
@@ -419,7 +330,8 @@ pub fn decl_parser<'a, 'src: 'a>() -> impl Parser<
         });
 
         // Variable declaration
-        let var_decl = select! { (Token::Var, _) => () }
+        let var_decl = text::keyword("var")
+            .padded()
             .ignore_then(ident.clone())
             .then(equal.ignore_then(expr.clone()).or_not())
             .then_ignore(semicolon.clone())
@@ -429,10 +341,12 @@ pub fn decl_parser<'a, 'src: 'a>() -> impl Parser<
         let param_list = ident
             .clone()
             .separated_by(comma)
+            .allow_trailing()
             .collect::<Vec<_>>()
             .delimited_by(lparen.clone(), rparen.clone());
 
-        let fun_decl = select! { (Token::Fun, _) => () }
+        let fun_decl = text::keyword("fun")
+            .padded()
             .ignore_then(ident.clone())
             .then(param_list)
             .then(stmt.clone())
@@ -450,13 +364,14 @@ pub fn decl_parser<'a, 'src: 'a>() -> impl Parser<
 }
 
 /// Parser for a full program
-pub fn program_parser<'a, 'src: 'a>() -> impl Parser<
-    'a,
-    &'a [(Token<'src>, SimpleSpan)],
+pub fn program_parser<'src>() -> impl Parser<
+    'src,
+    &'src str,
     Program<'src, &'src str, &'src str, ByteSpan>,
-    extra::Err<Simple<'a, (Token<'src>, SimpleSpan)>>,
+    extra::Err<Simple<'src, char>>,
 > {
     decl_parser()
+        .padded()
         .repeated()
         .collect()
         .map(|decls| Program { decls })
@@ -468,40 +383,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_lexer_numbers() {
-        let src = "42 3.14";
-        let tokens = lexer().parse(src).unwrap();
-        assert_eq!(tokens.len(), 2);
-        assert!(matches!(tokens[0].0, Token::Number(42.0)));
-        assert!(matches!(tokens[1].0, Token::Number(3.14)));
-    }
-
-    #[test]
-    fn test_lexer_operators() {
-        let src = "+ - * / == !=";
-        let tokens = lexer().parse(src).unwrap();
-        assert_eq!(tokens.len(), 6);
-        assert_eq!(tokens[0].0, Token::Plus);
-        assert_eq!(tokens[1].0, Token::Minus);
-        assert_eq!(tokens[2].0, Token::Star);
-        assert_eq!(tokens[3].0, Token::Slash);
-        assert_eq!(tokens[4].0, Token::EqualEqual);
-        assert_eq!(tokens[5].0, Token::BangEqual);
-    }
-
-    #[test]
     fn test_parser_literal() {
         let src = "42";
-        let tokens = lexer().parse(src).unwrap();
-        let ast = expr_parser().parse(&tokens).unwrap();
+        let ast = expr_parser().parse(src).unwrap();
         assert!(matches!(ast.value, Expression::NumberLiteral(42.0)));
     }
 
     #[test]
     fn test_parser_binary() {
         let src = "2 + 3";
-        let tokens = lexer().parse(src).unwrap();
-        let ast = expr_parser().parse(&tokens).unwrap();
+        let ast = expr_parser().parse(src).unwrap();
 
         if let Expression::Binary {
             left,
@@ -520,8 +411,7 @@ mod tests {
     #[test]
     fn test_parser_precedence() {
         let src = "2 + 3 * 4";
-        let tokens = lexer().parse(src).unwrap();
-        let ast = expr_parser().parse(&tokens).unwrap();
+        let ast = expr_parser().parse(src).unwrap();
 
         // Should parse as: 2 + (3 * 4)
         if let Expression::Binary {
@@ -553,8 +443,7 @@ mod tests {
     #[test]
     fn test_parser_parentheses() {
         let src = "(2 + 3) * 4";
-        let tokens = lexer().parse(src).unwrap();
-        let ast = expr_parser().parse(&tokens).unwrap();
+        let ast = expr_parser().parse(src).unwrap();
 
         // Should parse as: (2 + 3) * 4
         if let Expression::Binary {
@@ -586,8 +475,7 @@ mod tests {
     #[test]
     fn test_parser_unary() {
         let src = "-42";
-        let tokens = lexer().parse(src).unwrap();
-        let ast = expr_parser().parse(&tokens).unwrap();
+        let ast = expr_parser().parse(src).unwrap();
 
         if let Expression::Unary { operator, right } = ast.value {
             assert_eq!(operator, UOperator::MINUS);
@@ -600,8 +488,7 @@ mod tests {
     #[test]
     fn test_parser_string() {
         let src = r#""hello world""#;
-        let tokens = lexer().parse(src).unwrap();
-        let ast = expr_parser().parse(&tokens).unwrap();
+        let ast = expr_parser().parse(src).unwrap();
 
         assert!(matches!(
             ast.value,
@@ -612,8 +499,7 @@ mod tests {
     #[test]
     fn test_parser_comparison() {
         let src = "3 < 5";
-        let tokens = lexer().parse(src).unwrap();
-        let ast = expr_parser().parse(&tokens).unwrap();
+        let ast = expr_parser().parse(src).unwrap();
 
         if let Expression::Binary {
             left,
@@ -633,8 +519,7 @@ mod tests {
     fn test_parser_complex_expression() {
         // Test a more complex expression: (2 + 3) * 4 - 5 / 2
         let src = "(2 + 3) * 4 - 5 / 2";
-        let tokens = lexer().parse(src).unwrap();
-        let ast = expr_parser().parse(&tokens).unwrap();
+        let ast = expr_parser().parse(src).unwrap();
 
         // Just verify it parses successfully and pretty-prints
         let pretty = ast.value.pretty_print();
@@ -673,11 +558,7 @@ mod tests {
         ];
 
         for src in test_cases {
-            let tokens = lexer().parse(src).into_result();
-            assert!(tokens.is_ok(), "Failed to lex: {}", src);
-            let tokens = tokens.unwrap();
-
-            let ast = expr_parser().parse(&tokens).into_result();
+            let ast = expr_parser().parse(src).into_result();
             assert!(ast.is_ok(), "Failed to parse: {}", src);
 
             println!("{:20} => {}", src, ast.unwrap().value.pretty_print());
@@ -687,8 +568,7 @@ mod tests {
     #[test]
     fn test_parser_function_call() {
         let src = "foo(1, 2, 3)";
-        let tokens = lexer().parse(src).unwrap();
-        let ast = expr_parser().parse(&tokens).unwrap();
+        let ast = expr_parser().parse(src).unwrap();
 
         if let Expression::FunctionCall(func, args) = ast.value {
             assert!(matches!(func.value, Expression::Identifier(_)));
@@ -701,8 +581,7 @@ mod tests {
     #[test]
     fn test_parser_assignment() {
         let src = "x = 5";
-        let tokens = lexer().parse(src).unwrap();
-        let ast = expr_parser().parse(&tokens).unwrap();
+        let ast = expr_parser().parse(src).unwrap();
 
         if let Expression::Assignment(var, val) = ast.value {
             assert_eq!(var.0, "x");
@@ -715,8 +594,7 @@ mod tests {
     #[test]
     fn test_parser_logical_operators() {
         let src = "true and false or true";
-        let tokens = lexer().parse(src).unwrap();
-        let ast = expr_parser().parse(&tokens).unwrap();
+        let ast = expr_parser().parse(src).unwrap();
 
         // Should parse as: (true and false) or true
         if let Expression::Binary {
@@ -748,8 +626,7 @@ mod tests {
     #[test]
     fn test_stmt_var_decl() {
         let src = "var x = 10;";
-        let tokens = lexer().parse(src).unwrap();
-        let ast = decl_parser().parse(&tokens).unwrap();
+        let ast = decl_parser().parse(src).unwrap();
 
         if let Declaration::Var(var, Some(expr)) = ast {
             assert_eq!(var.0, "x");
@@ -765,8 +642,7 @@ mod tests {
             var x = 10;
             print x;
         "#;
-        let tokens = lexer().parse(src).unwrap();
-        let program = program_parser().parse(&tokens).unwrap();
+        let program = program_parser().parse(src).unwrap();
 
         assert_eq!(program.decls.len(), 2);
         assert!(matches!(program.decls[0], Declaration::Var(_, _)));
@@ -785,8 +661,7 @@ mod tests {
             }
             print add(2, 3);
         "#;
-        let tokens = lexer().parse(src).unwrap();
-        let program = program_parser().parse(&tokens).unwrap();
+        let program = program_parser().parse(src).unwrap();
 
         assert_eq!(program.decls.len(), 2);
 
@@ -816,8 +691,7 @@ mod tests {
                 i = i + 1;
             }
         "#;
-        let tokens = lexer().parse(src).unwrap();
-        let result = program_parser().parse(&tokens).into_result();
+        let result = program_parser().parse(src).into_result();
 
         assert!(result.is_ok(), "Failed to parse fibonacci program");
         let program = result.unwrap();

--- a/rs-code/loxlang/src/runtime.rs
+++ b/rs-code/loxlang/src/runtime.rs
@@ -343,13 +343,9 @@ mod tests {
         let env = ExecEnv::new(deps);
         let mut runtime = Runtime::new(env);
 
-        // Lex and parse using chumsky
-        let tokens = parse::chumsky_parser::lexer()
-            .parse(source)
-            .into_result()
-            .unwrap();
+        // Parse using chumsky
         let program = parse::chumsky_parser::program_parser()
-            .parse(&tokens)
+            .parse(source)
             .into_result()
             .unwrap();
         let program = crate::resolution::resolve(program, source).unwrap();

--- a/rs-code/loxlang/src/test_runner.rs
+++ b/rs-code/loxlang/src/test_runner.rs
@@ -1,5 +1,5 @@
 use crate::execution_env::{Deps, ExecEnv, Value};
-use crate::parse::chumsky_parser::{lexer, program_parser};
+use crate::parse::chumsky_parser::program_parser;
 use crate::runtime::Runtime;
 use chumsky::Parser;
 use regex::Regex;
@@ -119,12 +119,8 @@ impl TestCase {
         // Strip comments from source before parsing
         let source_without_comments = Self::strip_comments(&self.source);
 
-        let tokens = lexer()
-            .parse(&source_without_comments)
-            .into_result()
-            .map_err(|e| format!("Lexical error: {:?}", e))?;
         let program = program_parser()
-            .parse(&tokens)
+            .parse(&source_without_comments)
             .into_result()
             .map_err(|e| format!("Parse error: {:?}", e))?;
         let program = crate::resolution::resolve(program, &source_without_comments)

--- a/rs-code/loxwasm/src/lib.rs
+++ b/rs-code/loxwasm/src/lib.rs
@@ -84,48 +84,19 @@ pub fn eval_expr(src: String) -> LoxResult<f64> {
 fn eval_expr_inner(src: &str) -> Result<Value<'_>, LoxError> {
     use chumsky::Parser;
 
-    // Lex the source code
-    let tokens = chumsky_parser::lexer()
+    // Parse the source directly into an AST
+    let e = chumsky_parser::expr_parser()
         .parse(src)
         .into_result()
         .map_err(|errors| {
             // Take the first error
             let err = errors.into_iter().next().unwrap();
             let span = err.span();
-            // TODO integrate these errors with LoxError to simplify this
-            LoxError::LexicalError(parse::LexicalError {
-                src: src.to_string(),
-                source_offset: span.start.into(),
-            })
-        })?;
-
-    // Parse the tokens into an AST
-    let e = chumsky_parser::expr_parser()
-        .parse(&tokens)
-        .into_result()
-        .map_err(|errors| {
-            // Take the first error
-            let err = errors.into_iter().next().unwrap();
-            let token_span = err.span();
-
-            // Map token indices to character positions
-            let char_span = if token_span.start < tokens.len() {
-                let start_char = tokens[token_span.start].1.start;
-                let end_char = if token_span.end <= tokens.len() && token_span.end > 0 {
-                    tokens[token_span.end - 1].1.end
-                } else {
-                    tokens[token_span.start].1.end
-                };
-                miette::SourceSpan::new(start_char.into(), end_char - start_char)
-            } else {
-                // If the span is beyond the tokens, use the end of the source
-                miette::SourceSpan::new(src.len().into(), 0)
-            };
 
             LoxError::ParseError(parse::ParseError::UnexpectedToken {
                 src: src.to_string(),
-                span: char_span,
-                help: format!("Unexpected token while parsing expression"),
+                span: miette::SourceSpan::new(span.start.into(), span.end - span.start),
+                help: format!("Unexpected input while parsing expression"),
             })
         })?;
 
@@ -154,47 +125,19 @@ pub fn run_program(src: String) -> LoxResult<Vec<String>> {
 fn run_program_inner(src: &str) -> Result<Vec<String>, LoxError> {
     use chumsky::Parser;
 
-    // Lex the source code using chumsky
-    let tokens = chumsky_parser::lexer()
+    // Parse the program directly from source
+    let program = chumsky_parser::program_parser()
         .parse(src)
         .into_result()
         .map_err(|errors| {
             // Take the first error
             let err = errors.into_iter().next().unwrap();
             let span = err.span();
-            LoxError::LexicalError(parse::LexicalError {
-                src: src.to_string(),
-                source_offset: span.start.into(),
-            })
-        })?;
-
-    // Parse the program using chumsky
-    let program = chumsky_parser::program_parser()
-        .parse(&tokens)
-        .into_result()
-        .map_err(|errors| {
-            // Take the first error
-            let err = errors.into_iter().next().unwrap();
-            let token_span = err.span();
-
-            // Map token indices to character positions
-            let char_span = if token_span.start < tokens.len() {
-                let start_char = tokens[token_span.start].1.start;
-                let end_char = if token_span.end <= tokens.len() && token_span.end > 0 {
-                    tokens[token_span.end - 1].1.end
-                } else {
-                    tokens[token_span.start].1.end
-                };
-                miette::SourceSpan::new(start_char.into(), end_char - start_char)
-            } else {
-                // If the span is beyond the tokens, use the end of the source
-                miette::SourceSpan::new(src.len().into(), 0)
-            };
 
             LoxError::ParseError(parse::ParseError::UnexpectedToken {
                 src: src.to_string(),
-                span: char_span,
-                help: format!("Unexpected token while parsing program"),
+                span: miette::SourceSpan::new(span.start.into(), span.end - span.start),
+                help: format!("Unexpected input while parsing program"),
             })
         })?;
 

--- a/rs-code/loxwasm/src/lib.rs
+++ b/rs-code/loxwasm/src/lib.rs
@@ -3,7 +3,7 @@ use loxlang::execution_env::Deps;
 use loxlang::execution_env::Value;
 use loxlang::parse;
 use loxlang::parse::chumsky_parser;
-use loxlang::resolution::resolve;
+use loxlang::parse_program;
 use loxlang::resolution::resolve_expr_no_var;
 use loxlang::LoxError;
 use serde::{Deserialize, Serialize};
@@ -123,26 +123,7 @@ pub fn run_program(src: String) -> LoxResult<Vec<String>> {
 }
 
 fn run_program_inner(src: &str) -> Result<Vec<String>, LoxError> {
-    use chumsky::Parser;
-
-    // Parse the program directly from source
-    let program = chumsky_parser::program_parser()
-        .parse(src)
-        .into_result()
-        .map_err(|errors| {
-            // Take the first error
-            let err = errors.into_iter().next().unwrap();
-            let span = err.span();
-
-            LoxError::ParseError(parse::ParseError::UnexpectedToken {
-                src: src.to_string(),
-                span: miette::SourceSpan::new(span.start.into(), span.end - span.start),
-                help: format!("Unexpected input while parsing program"),
-            })
-        })?;
-
-    // Resolve variables
-    let program = resolve(program, &src)?;
+    let program = parse_program(src)?;
 
     let deps = TestDeps {
         printed: Vec::new(),


### PR DESCRIPTION
Replace the two-phase lexer-then-parser approach with a single combined
parser that parses directly from source strings. This simplifies the
architecture while maintaining modularity through parser combinators.

Changes:
- Remove Token enum and lexer() function from chumsky_parser.rs
- Update expr_parser, decl_parser, and program_parser to work directly
  on &str instead of &[(Token, SimpleSpan)]
- Replace select! token matchers with direct text parsing using
  text::keyword(), just(), and other Chumsky primitives
- Simplify lifetime parameters (now just 'src instead of 'a and 'src)
- Update all call sites in lib.rs, main.rs, runtime.rs, test_runner.rs,
  and loxwasm to use the combined parser
- Update all tests to parse directly from source strings

The code remains modular with separate parsing functions for expressions,
declarations, and programs, but they now combine into a single parser
rather than requiring a separate lexing phase.